### PR TITLE
Incorporate test framework into code pipeline

### DIFF
--- a/.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml
+++ b/.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml
@@ -31,6 +31,9 @@ jobs:
           tenant-id: ${{ secrets.TEACHERSEDDOAI_AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.TEACHERSEDDOAI_AZURE_SUBSCRIPTION_ID }}
 
+      - name: Run tests
+        run: pnpm test
+
       - name: Build and push container image to registry
         uses: azure/container-apps-deploy-action@v2
         with:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,4 +6,7 @@ if git diff --cached --name-only | grep -q "package.json"; then
   echo "📦 Updating pnpm lockfile..."
   pnpm install --lockfile-only
   git add pnpm-lock.yaml
-fi 
+fi
+
+# Run tests before committing code
+pnpm test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,9 @@ repos:
         language: system
         files: package.json
         pass_filenames: false 
+      - id: run-tests
+        name: Run Tests
+        entry: pnpm test
+        language: system
+        files: .
+        pass_filenames: false

--- a/__tests__/api/auth.test.ts
+++ b/__tests__/api/auth.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { handleAuth, getSession } from '@auth0/nextjs-auth0';
 import { Response } from 'node-fetch';
 

--- a/__tests__/api/langgraph.test.ts
+++ b/__tests__/api/langgraph.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/[..._path]/route";
 
@@ -122,4 +123,4 @@ describe("LangGraph API Route Handler", () => {
         // Verify body wasn't modified
         expect(options.body).toBe(JSON.stringify(originalBody));
     });
-}); 
+});

--- a/__tests__/api/route.test.ts
+++ b/__tests__/api/route.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/[..._path]/route";
 

--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { handleAuth } from '@auth0/nextjs-auth0';
 
 // Mock the Auth0 SDK
@@ -29,4 +30,4 @@ describe('Auth Handler', () => {
 
     expect(mockHandler).toHaveBeenCalledWith(request);
   });
-}); 
+});

--- a/__tests__/pages/dashboard.test.tsx
+++ b/__tests__/pages/dashboard.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import { getSession } from '@auth0/nextjs-auth0';
 import { redirect } from 'next/navigation';
@@ -45,4 +46,4 @@ describe('DashboardPage', () => {
     expect(screen.getByText(`Welcome, ${mockUser.name}!`)).toBeInTheDocument();
     expect(container.textContent).toContain(JSON.stringify(mockUser, null, 2));
   });
-}); 
+});

--- a/__tests__/pages/protected/dashboard.test.tsx
+++ b/__tests__/pages/protected/dashboard.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import Dashboard from '@/app/protected/dashboard/page';
 import { getSession } from '@auth0/nextjs-auth0';


### PR DESCRIPTION
Fixes #23

Incorporate the test framework into the code pipeline.

* **Test Imports:**
  - Add Jest imports to `__tests__/api/auth.test.ts`, `__tests__/api/langgraph.test.ts`, `__tests__/api/route.test.ts`, `__tests__/auth.test.ts`, `__tests__/pages/dashboard.test.tsx`, and `__tests__/pages/protected/dashboard.test.tsx`.

* **GitHub Actions Workflow:**
  - Add a new step to run tests before the `Build and push container image to registry` step in `.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml`.

* **Husky Pre-commit Hook:**
  - Add a new line to run tests before committing code in `.husky/pre-commit`.

* **Pre-commit Configuration:**
  - Add a new hook for running tests before committing code in `.pre-commit-config.yaml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hey-aw/teachers-assistant-ui/pull/24?shareId=943632d6-47c8-4fe2-9cdc-00cc560bb822).