### PR TITLE
Fix build failure by ensuring pnpm is installed

### DIFF
--- a/.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml
+++ b/.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout to the branch
         uses: actions/checkout@v2
 
+      - name: Install pnpm
+        run: npm install -g pnpm
+
       - name: Install dependencies
         run: pnpm install
 

--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ bun dev
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+
+## Note
+
+Ensure `pnpm` is installed before running any commands. You can install it globally using the following command:
+
+```bash
+npm install -g pnpm
+```


### PR DESCRIPTION
Fixes #32

Add a step to install `pnpm` in the GitHub Actions workflow file to resolve the build failure.

* **README.md**
  - Add a note to ensure `pnpm` is installed before running any commands.
  - Provide the command to install `pnpm` globally.

* **.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml**
  - Add a step to install `pnpm` before the install step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hey-aw/teachers-assistant-ui/pull/33?shareId=838513d5-5574-466f-9c21-e920250f6d44).