### PR TITLE
Fix build warning in GitHub Actions workflow

### DIFF
--- a/.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml
+++ b/.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml
@@ -44,12 +44,12 @@ jobs:
         uses: azure/container-apps-deploy-action@v2
         with:
           appSourcePath: ${{ github.workspace }}
-          _dockerfilePathKey_: _dockerfilePath_
+          dockerfilePath: _dockerfilePath_
           registryUrl: eddoazurecontainers.azurecr.io
           registryUsername: ${{ secrets.TEACHERSEDDOAI_REGISTRY_USERNAME }}
           registryPassword: ${{ secrets.TEACHERSEDDOAI_REGISTRY_PASSWORD }}
           containerAppName: teachers-eddo-ai
           resourceGroup: eddo-container-apps
           imageToBuild: eddoazurecontainers.azurecr.io/teachers-eddo-ai:${{ github.sha }}
-          _buildArgumentsKey_: |
+          buildArguments: |
             _buildArgumentsValues_

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN pnpm install --frozen-lockfile
 COPY . .
 
 # Run tests
-RUN pnpm run test
+RUN pnpm test
 
 # Build the application
 RUN pnpm run build


### PR DESCRIPTION
Fixes #27

Resolve build warning regarding unexpected input(s) '_dockerfilePathKey_' and '_buildArgumentsKey_'.

* **Dockerfile**
  - Replace `RUN pnpm run test` with `RUN pnpm test` to match the script name.

* **.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml**
  - Replace `_dockerfilePathKey_` with `dockerfilePath`.
  - Replace `_buildArgumentsKey_` with `buildArguments`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hey-aw/teachers-assistant-ui/pull/34?shareId=efa24750-dddc-48ae-9ecf-526cae5553f8).