### PR TITLE
Implement i18n library

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { UserProvider } from '@auth0/nextjs-auth0/client';
 import Navbar from "@/components/Navbar";
 import "./globals.css";
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../i18n';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,12 +31,14 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <UserProvider>
-          <Navbar />
-          <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-            {children}
-          </main>
-        </UserProvider>
+        <I18nextProvider i18n={i18n}>
+          <UserProvider>
+            <Navbar />
+            <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+              {children}
+            </main>
+          </UserProvider>
+        </I18nextProvider>
       </body>
     </html>
   );

--- a/app/protected/dashboard/page.tsx
+++ b/app/protected/dashboard/page.tsx
@@ -1,8 +1,10 @@
 import { getSession } from '@auth0/nextjs-auth0';
 import { redirect } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 
 export default async function DashboardPage() {
     const session = await getSession();
+    const { t } = useTranslation();
 
     if (!session?.user) {
         redirect('/api/auth/login');
@@ -10,14 +12,14 @@ export default async function DashboardPage() {
 
     return (
         <div className="space-y-6">
-            <h1 className="text-2xl font-bold">Protected Dashboard</h1>
+            <h1 className="text-2xl font-bold">{t('protected_dashboard')}</h1>
             <div className="bg-white shadow sm:rounded-lg">
                 <div className="px-4 py-5 sm:p-6">
-                    <h2 className="text-lg font-medium">Welcome, {session.user.name}!</h2>
+                    <h2 className="text-lg font-medium">{t('welcome_user', { name: session.user.name })}</h2>
                     <div className="mt-3 text-sm text-gray-600">
-                        <p>This is a protected page. You can only see this if you're logged in.</p>
+                        <p>{t('protected_page_message')}</p>
                         <div className="mt-4">
-                            <h3 className="font-medium">Your Profile:</h3>
+                            <h3 className="font-medium">{t('your_profile')}</h3>
                             <pre className="mt-2 p-4 bg-gray-50 rounded-md overflow-auto">
                                 {JSON.stringify(session.user, null, 2)}
                             </pre>
@@ -27,4 +29,4 @@ export default async function DashboardPage() {
             </div>
         </div>
     );
-} 
+}

--- a/components/AuthButton.tsx
+++ b/components/AuthButton.tsx
@@ -2,17 +2,19 @@
 
 import { useUser } from '@auth0/nextjs-auth0/client';
 import Image from 'next/image';
+import { useTranslation } from 'react-i18next';
 
 export default function AuthButton() {
     const { user, error, isLoading } = useUser();
+    const { t } = useTranslation();
 
-    if (isLoading) return <div>Loading...</div>;
-    if (error) return <div>Error: {error.message}</div>;
+    if (isLoading) return <div>{t('loading')}</div>;
+    if (error) return <div>{t('error', { message: error.message })}</div>;
 
     if (user) {
         return (
             <div className="flex items-center gap-4">
-                <span className="hidden sm:block">Welcome, {user.nickname || user.name}!</span>
+                <span className="hidden sm:block">{t('welcome_user', { name: user.nickname || user.name })}</span>
                 {user.picture && (
                     <Image
                         src={user.picture}
@@ -26,7 +28,7 @@ export default function AuthButton() {
                     href="/api/auth/logout"
                     className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-500"
                 >
-                    Logout
+                    {t('logout')}
                 </a>
             </div>
         );
@@ -37,7 +39,7 @@ export default function AuthButton() {
             href="/api/auth/login"
             className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-500"
         >
-            Login
+            {t('login')}
         </a>
     );
-} 
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,8 +2,15 @@
 
 import Link from 'next/link';
 import AuthButton from './AuthButton';
+import { useTranslation } from 'react-i18next';
 
 export default function Navbar() {
+    const { t, i18n } = useTranslation();
+
+    const changeLanguage = (lng: string) => {
+        i18n.changeLanguage(lng);
+    };
+
     return (
         <nav className="fixed top-0 left-0 right-0 h-[60px] bg-white border-b border-gray-200 z-10 flex items-center px-4">
             <div className="flex items-center justify-between w-full max-w-7xl mx-auto">
@@ -14,8 +21,16 @@ export default function Navbar() {
                 </div>
                 <div className="flex items-center gap-4">
                     <AuthButton />
+                    <div>
+                        <button onClick={() => changeLanguage('en')} className="px-2 py-1 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-500">
+                            {t('english')}
+                        </button>
+                        <button onClick={() => changeLanguage('es')} className="px-2 py-1 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-500 ml-2">
+                            {t('spanish')}
+                        </button>
+                    </div>
                 </div>
             </div>
         </nav>
     );
-} 
+}

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,54 @@
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+const resources = {
+  en: {
+    translation: {
+      "welcome": "Welcome",
+      "protected_dashboard": "Protected Dashboard",
+      "welcome_user": "Welcome, {{name}}!",
+      "protected_page_message": "This is a protected page. You can only see this if you're logged in.",
+      "your_profile": "Your Profile:",
+      "loading": "Loading...",
+      "error": "Error: {{message}}",
+      "login": "Login",
+      "logout": "Logout",
+      "please_log_in": "Please log in to view your profile.",
+      "profile_information": "Profile Information",
+      "language": "Language",
+      "english": "English",
+      "spanish": "Spanish"
+    }
+  },
+  es: {
+    translation: {
+      "welcome": "Bienvenido",
+      "protected_dashboard": "Tablero Protegido",
+      "welcome_user": "¡Bienvenido, {{name}}!",
+      "protected_page_message": "Esta es una página protegida. Solo puedes verla si has iniciado sesión.",
+      "your_profile": "Tu Perfil:",
+      "loading": "Cargando...",
+      "error": "Error: {{message}}",
+      "login": "Iniciar sesión",
+      "logout": "Cerrar sesión",
+      "please_log_in": "Por favor, inicia sesión para ver tu perfil.",
+      "profile_information": "Información del Perfil",
+      "language": "Idioma",
+      "english": "Inglés",
+      "spanish": "Español"
+    }
+  }
+};
+
+i18next
+  .use(initReactI18next)
+  .init({
+    resources,
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false
+    }
+  });
+
+export default i18next;


### PR DESCRIPTION
Fixes #4

Implement i18n library for internationalizing user-facing strings.

* **Add i18n configuration**: Create `i18n.ts` to initialize `i18next` with English and Spanish translations.
* **Update layout**: Modify `app/layout.tsx` to wrap `UserProvider` with `I18nextProvider`.
* **Internationalize dashboard page**: Modify `app/protected/dashboard/page.tsx` to use `useTranslation` and replace hardcoded strings with `t` function.
* **Internationalize AuthButton**: Modify `components/AuthButton.tsx` to use `useTranslation` and replace hardcoded strings with `t` function.
* **Add language switcher**: Modify `components/Navbar.tsx` to include buttons for switching between English and Spanish.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hey-aw/teachers-assistant-ui/pull/37?shareId=1e24247b-e1fb-470c-b2d2-df61c029daed).