### PR TITLE
Fix failed build

### DIFF
--- a/.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml
+++ b/.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml
@@ -43,7 +43,7 @@ jobs:
         uses: Azure/container-apps-deploy-action@5f5f4c56ca90376e3cfbd76ba8fe8533c784e655
         with:
           appSourcePath: ${{ github.workspace }}
-          dockerfilePath: _dockerfilePath_
+          dockerfilePath: Dockerfile
           registryUrl: eddoazurecontainers.azurecr.io
           registryUsername: ${{ secrets.TEACHERSEDDOAI_REGISTRY_USERNAME }}
           registryPassword: ${{ secrets.TEACHERSEDDOAI_REGISTRY_PASSWORD }}
@@ -51,7 +51,7 @@ jobs:
           resourceGroup: eddo-container-apps
           imageToBuild: eddoazurecontainers.azurecr.io/teachers-eddo-ai:${{ github.sha }}
           buildArguments: |
-            _buildArgumentsValues_
+            KEY1=value1 KEY2=value2
 
       - name: Wait for container to be ready
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:lts-alpine
 
+ARG KEY1
+ARG KEY2
+
 # Enable pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
@@ -26,6 +29,9 @@ EXPOSE 3000
 # Use non-root user
 RUN chown -R node /usr/src/app
 USER node
+
+ENV KEY1=${KEY1}
+ENV KEY2=${KEY2}
 
 # Start the application
 CMD ["pnpm", "start"]


### PR DESCRIPTION
Fixes #50

Update the `buildArguments` argument format in the Dockerfile and GitHub Actions workflow file.

* **Dockerfile**
  - Add `ARG` instructions for `KEY1` and `KEY2`.
  - Add `ENV` instructions for `KEY1` and `KEY2`.

* **.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml**
  - Update `dockerfilePath` to `Dockerfile`.
  - Update `buildArguments` to `KEY1=value1 KEY2=value2`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hey-aw/teachers-assistant-ui/pull/51?shareId=319bde9c-40b6-4fe7-aaaf-1b34c9dcf085).