### PR TITLE
Add Docker build validation step to workflow

### DIFF
--- a/.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml
+++ b/.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build Docker image
+        run: docker build -t my-app .
+
+      - name: Validate Docker build
+        run: docker run --rm my-app
+
       - name: Run tests
         run: pnpm test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,3 +35,7 @@ ENV KEY2=${KEY2}
 
 # Start the application
 CMD ["pnpm", "start"]
+
+# Start of build validation step
+RUN docker build -t my-app .
+RUN docker run --rm my-app


### PR DESCRIPTION
Fixes #52

Add a step to the pull request checks that validates the build from the Dockerfile.

* **Dockerfile**
  - Add a comment to indicate the start of the build validation step.
  - Add a step to build the Docker image using `docker build -t my-app .`.
  - Add a step to validate the build using `docker run --rm my-app`.

* **.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml**
  - Add a new step after the "Install dependencies" step to build the Docker image.
  - Add a new step after the Docker build step to validate the build.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hey-aw/teachers-assistant-ui/pull/55?shareId=1cb18ba5-94e3-4a14-915b-160c069c2051).