### PR TITLE
Update actions/upload-artifact to v3

### DIFF
--- a/.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml
+++ b/.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml
@@ -62,7 +62,7 @@ jobs:
           sleep 60
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifacts
           path: |

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-dom": "19.0.0",
     "react-i18next": "^15.4.0",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "actions/upload-artifact": "v3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",


### PR DESCRIPTION
Fixes #61

Update the build process to use a supported version of `actions/upload-artifact`.

* **package.json**
  - Add `actions/upload-artifact` version `v3` to the `dependencies` section.

* **.github/workflows/teachers-eddo-ai-AutoDeployTrigger-f672ecc5-37c2-4861-a895-4d81560fed74.yml**
  - Update `actions/upload-artifact` to version `v3` in the `Upload build artifacts` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hey-aw/teachers-assistant-ui/pull/62?shareId=66b00423-8eb5-4947-b2ed-fd1469f25916).